### PR TITLE
feat: add webchat-user-data example

### DIFF
--- a/examples/webchat-user-data/README.md
+++ b/examples/webchat-user-data/README.md
@@ -1,0 +1,127 @@
+# Webchat User Data
+
+Demonstrates how to pass user data from a website to a Botpress bot through the webchat widget using `updateUser` and `getUserData`.
+
+## Use Case
+
+When your bot is embedded on a website where users are already authenticated (e.g., a customer portal), you often need to pass session data — like a JWT, email, or user ID — from the website to the bot so it can perform authenticated actions without asking the user to re-identify themselves.
+
+This example shows:
+
+- How to pass arbitrary data from the website to the bot via `window.botpress.updateUser()`
+- How to read that data inside the bot using `actions.webchat.getUserData()`
+- The critical timing requirement: `updateUser` **must** be called on the `webchat:ready` event (not `webchat:initialized`)
+
+## How It Works
+
+### Website Side
+
+The website loads the webchat widget and calls `updateUser({ data: { ... } })` on the `webchat:ready` event:
+
+```html
+<div id="webchat"></div>
+
+<script src="https://cdn.botpress.cloud/webchat/v3.6/inject.js"></script>
+<script>
+  window.botpress.init({
+    botId: "YOUR_BOT_ID",
+    clientId: "YOUR_CLIENT_ID",
+    selector: "#webchat",   // Embeds the webchat inside the div
+  });
+
+  window.botpress.on("webchat:ready", function () {
+    window.botpress.updateUser({
+      data: {
+        jwt: "eyJhbGciOiJIUzI1...",      // Session JWT from your auth system
+        email: "user@example.com",
+        plan: "premium",
+      },
+    });
+  });
+</script>
+```
+
+### Bot Side
+
+In the conversation handler, the bot reads the user data using `actions.webchat.getUserData()`:
+
+```typescript
+const ud = await actions.webchat.getUserData({ userId: event?.userId as string });
+const jwt = (ud as any)?.userData?.jwt;
+const email = (ud as any)?.userData?.email;
+```
+
+## Critical Details
+
+### Timing: `webchat:ready`, NOT `webchat:initialized`
+
+The `updateUser` call **must** happen on the `webchat:ready` event. If called on `webchat:initialized`, the data will **not** be persisted to the server and `getUserData` will return `{}`.
+
+- `webchat:initialized` — The widget is loaded but the connection is not yet established
+- `webchat:ready` — The connection is fully established and data can be persisted
+
+### Embedded Mode Recommended
+
+For the most reliable data flow, embed the webchat inside a page element using the `selector` property in `botpress.init()`. The webchat element ID can be configured in your bot's Dashboard under **Webchat > Deploy Settings > Chat Interface > Embedded**.
+
+### `getUserData` Returns `{ userData: { ... } }`
+
+The data is nested under `userData` in the response. All values are strings:
+
+```typescript
+const result = await actions.webchat.getUserData({ userId });
+// result = { userData: { jwt: "eyJ...", email: "user@example.com", plan: "premium" } }
+```
+
+### Error Handling for Multi-Channel Bots
+
+If your bot also handles the `chat` channel, `getUserData` will throw on non-webchat conversations. Always wrap it in a try/catch:
+
+```typescript
+try {
+  const ud = await actions.webchat.getUserData({ userId: event?.userId as string });
+  // use ud.userData...
+} catch {
+  // Not a webchat channel — skip
+}
+```
+
+## Key Components
+
+### Configuration (`agent.config.ts`)
+
+Declares the webchat integration and user state for persisting the extracted data across tool calls.
+
+### Conversation Handler (`src/conversations/webchat.ts`)
+
+Reads user data via `getUserData` on every message and stores it in `user.state` for tools to access.
+
+### Sample Page (`website/index.html`)
+
+A minimal HTML page demonstrating the website-side integration pattern.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   bun install
+   ```
+
+2. Update `website/index.html` with your bot's `botId` and `clientId` (from your Dashboard)
+
+3. Start development server:
+   ```bash
+   adk dev
+   ```
+
+4. Serve the sample page:
+   ```bash
+   npx serve website
+   ```
+
+5. Open the page, paste a test value, and chat with the bot
+
+6. Deploy:
+   ```bash
+   adk deploy
+   ```

--- a/examples/webchat-user-data/agent.config.ts
+++ b/examples/webchat-user-data/agent.config.ts
@@ -1,0 +1,26 @@
+import { z, defineConfig } from "@botpress/runtime";
+
+export default defineConfig({
+  name: "webchat-user-data",
+  description:
+    "Demonstrates passing user data from a website to the bot via webchat updateUser / getUserData",
+
+  defaultModels: {
+    autonomous: "openai:gpt-4.1-mini-2025-04-14",
+    zai: "openai:gpt-4.1-mini-2025-04-14",
+  },
+
+  user: {
+    state: z.object({
+      jwt: z.string().optional().describe("JWT extracted from webchat user data"),
+      email: z.string().optional().describe("Email extracted from webchat user data"),
+      plan: z.string().optional().describe("Plan extracted from webchat user data"),
+    }),
+  },
+
+  dependencies: {
+    integrations: {
+      webchat: { version: "webchat@0.3.0", enabled: true },
+    },
+  },
+});

--- a/examples/webchat-user-data/package.json
+++ b/examples/webchat-user-data/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "webchat-user-data",
+  "version": "1.0.0",
+  "description": "Pass user data from a website to a Botpress bot via webchat updateUser / getUserData",
+  "packageManager": "bun@1.3.2",
+  "type": "module",
+  "scripts": {
+    "dev": "adk dev",
+    "build": "adk build",
+    "deploy": "adk deploy"
+  },
+  "dependencies": {
+    "@botpress/runtime": "^1.13.17"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/webchat-user-data/src/conversations/webchat.ts
+++ b/examples/webchat-user-data/src/conversations/webchat.ts
@@ -1,0 +1,50 @@
+import { Conversation, user, actions } from "@botpress/runtime";
+
+const WEBCHAT_USER_DATA_TIMEOUT_MS = 2000;
+
+export default new Conversation({
+  channel: "webchat.channel",
+
+  async handler({ type, event, execute }) {
+    if (type !== "message") return;
+
+    if (!user.state.jwt) {
+      try {
+        const userId = (event as any)?.userId as string | undefined;
+        const ud = await Promise.race([
+          actions.webchat.getUserData({ userId: userId as string }),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("timeout")),
+              WEBCHAT_USER_DATA_TIMEOUT_MS
+            )
+          ),
+        ]);
+
+        const d = (ud as any)?.userData ?? {};
+        if (d.jwt) user.state.jwt = d.jwt;
+        if (d.email) user.state.email = d.email;
+        if (d.plan) user.state.plan = d.plan;
+      } catch {
+        // getUserData unavailable (non-webchat channel or timeout)
+      }
+    }
+
+    const authenticated = !!user.state.jwt;
+
+    await execute({
+      instructions: [
+        "You are a helpful assistant.",
+        "",
+        "## Session Context",
+        `- Authenticated: ${authenticated ? "YES" : "NO"}`,
+        authenticated ? `- Email: ${user.state.email ?? "unknown"}` : "",
+        authenticated ? `- Plan: ${user.state.plan ?? "unknown"}` : "",
+        "",
+        !authenticated
+          ? "The user is not logged in. You can still answer general questions."
+          : "The user is logged in. You can access their account data.",
+      ].join("\n"),
+    });
+  },
+});

--- a/examples/webchat-user-data/tsconfig.json
+++ b/examples/webchat-user-data/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "paths": {
+      "@botpress/runtime/_types/*": ["./.adk/*-types"]
+    }
+  },
+  "include": ["src/**/*", ".adk/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/webchat-user-data/website/index.html
+++ b/examples/webchat-user-data/website/index.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Webchat User Data — Example</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #111; color: #ddd; display: flex; min-height: 100vh; }
+    .sidebar { width: 340px; padding: 32px 24px; border-right: 1px solid #333; display: flex; flex-direction: column; gap: 16px; }
+    h1 { font-size: 18px; color: #fff; }
+    label { font-size: 12px; font-weight: 600; color: #999; }
+    input, textarea { width: 100%; padding: 8px; background: #1a1a2e; border: 1px solid #333; border-radius: 6px; color: #eee; font-family: monospace; font-size: 12px; }
+    input:focus, textarea:focus { outline: none; border-color: #7c5cfc; }
+    button { padding: 10px; background: #7c5cfc; color: #fff; border: none; border-radius: 6px; font-weight: 600; cursor: pointer; }
+    button:hover { background: #6a4ce0; }
+    button:disabled { background: #444; cursor: not-allowed; }
+    .status { font-size: 12px; padding: 6px 10px; border-radius: 4px; }
+    .connected { background: #1a3a2a; color: #4ade80; }
+    .waiting { background: #3a2a1a; color: #fbbf24; }
+    .chat { flex: 1; }
+    #webchat { height: 100%; }
+    .hint { font-size: 11px; color: #666; line-height: 1.4; }
+  </style>
+</head>
+<body>
+
+  <div class="sidebar">
+    <h1>Webchat User Data</h1>
+    <p class="hint">
+      This page demonstrates passing data from a website to a Botpress bot using
+      <code>updateUser</code>. Enter values below and click <strong>Connect</strong>.
+      The bot will receive these values via <code>getUserData</code>.
+    </p>
+
+    <label for="jwt-input">JWT / Session Token</label>
+    <input id="jwt-input" placeholder="eyJhbGciOiJIUzI1NiIs..." />
+
+    <label for="email-input">Email</label>
+    <input id="email-input" placeholder="user@example.com" />
+
+    <label for="plan-input">Plan</label>
+    <input id="plan-input" placeholder="premium" />
+
+    <button id="connect-btn">Connect</button>
+    <div id="status" class="status waiting">Not connected</div>
+
+    <p class="hint">
+      <strong>How it works:</strong> On <code>webchat:ready</code>, the page calls
+      <code>window.botpress.updateUser({ data: { jwt, email, plan } })</code>.
+      The bot reads it with <code>actions.webchat.getUserData()</code>.
+    </p>
+  </div>
+
+  <div class="chat">
+    <!-- The webchat embeds inside this element -->
+    <div id="webchat"></div>
+  </div>
+
+  <script>
+    var jwtInput = document.getElementById('jwt-input')
+    var emailInput = document.getElementById('email-input')
+    var planInput = document.getElementById('plan-input')
+    var connectBtn = document.getElementById('connect-btn')
+    var statusEl = document.getElementById('status')
+
+    connectBtn.addEventListener('click', function () {
+      var jwt = jwtInput.value.trim()
+      var email = emailInput.value.trim()
+      var plan = planInput.value.trim()
+
+      connectBtn.disabled = true
+      statusEl.textContent = 'Loading webchat...'
+
+      var s = document.createElement('script')
+      s.src = 'https://cdn.botpress.cloud/webchat/v3.6/inject.js'
+      s.onload = function () {
+        var poll = setInterval(function () {
+          if (!window.botpress || !window.botpress.on) return
+          clearInterval(poll)
+
+          window.botpress.on('webchat:ready', function () {
+            // --- THIS IS THE KEY CALL ---
+            // Data passed here is available in the bot via:
+            //   actions.webchat.getUserData({ userId: event.userId })
+            window.botpress.updateUser({
+              data: { jwt: jwt, email: email, plan: plan },
+            })
+            statusEl.textContent = 'Connected'
+            statusEl.className = 'status connected'
+          })
+
+          // Replace these with YOUR bot's botId and clientId from the Dashboard
+          window.botpress.init({
+            botId: 'YOUR_BOT_ID',
+            clientId: 'YOUR_CLIENT_ID',
+            selector: '#webchat',
+          })
+        }, 50)
+      }
+      document.body.appendChild(s)
+    })
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a new example demonstrating how to pass user data from a website to a Botpress bot through the webchat widget using `updateUser` and `getUserData`.

This pattern is needed when bots are embedded on authenticated websites (customer portals, dashboards) and need access to session data like JWTs, emails, or plan info without asking users to re-identify.

## Key Details

- **Critical timing**: `updateUser` must be called on `webchat:ready`, NOT `webchat:initialized`. Data written on `initialized` does not persist to the server.
- **Embedded mode recommended**: Use `selector` in `botpress.init()` to embed the webchat in a page element for reliable data flow.
- **Bot reads via `getUserData`**: `actions.webchat.getUserData({ userId: event.userId })` returns `{ userData: { key: value } }`.

## Files

- `README.md` -- Full documentation with code examples and gotchas
- `agent.config.ts` -- Config with webchat integration and user state schema
- `src/conversations/webchat.ts` -- Conversation handler with getUserData + timeout pattern
- `website/index.html` -- Sample HTML page showing the website-side integration
- `package.json` + `tsconfig.json` -- Standard ADK scaffolding
